### PR TITLE
Enforce captcha validation during login

### DIFF
--- a/core/app/api/v2/auth.go
+++ b/core/app/api/v2/auth.go
@@ -26,11 +26,9 @@ func (b *BaseApi) Login(c *gin.Context) {
 		return
 	}
 
-	if !req.IgnoreCaptcha {
-		if errMsg := captcha.VerifyCode(req.CaptchaID, req.Captcha); errMsg != "" {
-			helper.BadAuth(c, errMsg, nil)
-			return
-		}
+	if errMsg := captcha.VerifyCode(req.CaptchaID, req.Captcha); errMsg != "" {
+		helper.BadAuth(c, errMsg, nil)
+		return
 	}
 	entranceItem := c.Request.Header.Get("EntranceCode")
 	var entrance []byte

--- a/core/utils/captcha/captcha.go
+++ b/core/utils/captcha/captcha.go
@@ -10,12 +10,17 @@ import (
 var store = base64Captcha.DefaultMemStore
 
 func VerifyCode(codeID string, code string) string {
-	if codeID == "" {
+	codeID = strings.TrimSpace(codeID)
+	code = strings.TrimSpace(code)
+
+	if codeID == "" || code == "" {
 		return "ErrCaptchaCode"
 	}
-	vv := store.Get(codeID, true)
-	vv = strings.TrimSpace(vv)
-	code = strings.TrimSpace(code)
+
+	vv := strings.TrimSpace(store.Get(codeID, true))
+	if vv == "" {
+		return "ErrCaptchaCode"
+	}
 
 	if strings.EqualFold(vv, code) {
 		return ""

--- a/frontend/src/api/interface/auth.ts
+++ b/frontend/src/api/interface/auth.ts
@@ -2,7 +2,6 @@ export namespace Login {
     export interface ReqLoginForm {
         name: string;
         password: string;
-        ignoreCaptcha: boolean;
         captcha: string;
         captchaID: string;
         authMethod: string;

--- a/frontend/src/store/interface/index.ts
+++ b/frontend/src/store/interface/index.ts
@@ -38,7 +38,6 @@ export interface GlobalState {
     isOnRestart: boolean;
     agreeLicense: boolean;
     hasNewVersion: boolean;
-    ignoreCaptcha: boolean;
     device: DeviceType;
     lastFilePath: string;
     currentDB: string;

--- a/frontend/src/store/modules/global.ts
+++ b/frontend/src/store/modules/global.ts
@@ -33,7 +33,6 @@ const GlobalStore = defineStore({
         isOnRestart: false,
         agreeLicense: false,
         hasNewVersion: false,
-        ignoreCaptcha: true,
         device: DeviceType.Desktop,
         lastFilePath: '',
         currentDB: '',

--- a/frontend/src/views/login/components/login-form.vue
+++ b/frontend/src/views/login/components/login-form.vue
@@ -96,7 +96,7 @@
                             ></el-input>
                         </el-form-item>
                         <el-row :gutter="10">
-                            <el-col :span="12" v-if="!globalStore.ignoreCaptcha">
+                            <el-col :span="12">
                                 <el-form-item prop="captcha">
                                     <el-input
                                         v-model.trim="loginForm.captcha"
@@ -105,7 +105,7 @@
                                     ></el-input>
                                 </el-form-item>
                             </el-col>
-                            <el-col :span="12" v-if="!globalStore.ignoreCaptcha">
+                            <el-col :span="12">
                                 <img
                                     class="w-full h-10"
                                     v-if="captcha.imagePath"
@@ -220,7 +220,6 @@ const loginFormRef = ref<FormInstance>();
 const loginForm = reactive({
     name: '',
     password: '',
-    ignoreCaptcha: true,
     captcha: '',
     captchaID: '',
     authMethod: 'session',
@@ -231,6 +230,7 @@ const loginForm = reactive({
 const loginRules = reactive({
     name: [{ required: true, validator: checkUsername, trigger: 'blur' }],
     password: [{ required: true, validator: checkPassword, trigger: 'blur' }],
+    captcha: [{ required: true, message: i18n.t('commons.login.errorCaptcha'), trigger: 'blur' }],
     agreeLicense: [{ required: true, validator: checkAgreeLicense, trigger: 'blur' }],
 });
 
@@ -324,13 +324,12 @@ const login = (formEl: FormInstance | undefined) => {
         let requestLoginForm = {
             name: loginForm.name,
             password: encryptPassword(loginForm.password),
-            ignoreCaptcha: globalStore.ignoreCaptcha,
             captcha: loginForm.captcha,
             captchaID: captcha.captchaID,
             authMethod: 'session',
             language: loginForm.language,
         };
-        if (!globalStore.ignoreCaptcha && requestLoginForm.captcha == '') {
+        if (requestLoginForm.captcha == '') {
             errCaptcha.value = true;
             return;
         }
@@ -338,7 +337,6 @@ const login = (formEl: FormInstance | undefined) => {
             isLoggingIn = true;
             loading.value = true;
             const res = await loginApi(requestLoginForm);
-            globalStore.ignoreCaptcha = true;
             if (res.data.mfaStatus === 'Enable') {
                 mfaShow.value = true;
                 errMfaInfo.value = false;
@@ -365,7 +363,6 @@ const login = (formEl: FormInstance | undefined) => {
                     return;
                 }
                 if (res.message === 'ErrAuth') {
-                    globalStore.ignoreCaptcha = false;
                     errCaptcha.value = false;
                     errAuthInfo.value = true;
                     loginVerify();
@@ -477,9 +474,7 @@ onMounted(() => {
     globalStore.isOnRestart = false;
     getSetting();
     getXpackSettingForTheme();
-    if (!globalStore.ignoreCaptcha) {
-        loginVerify();
-    }
+    loginVerify();
     document.title = globalStore.themeConfig.panelName;
     loginBtnLinkColor.value = globalStore.themeConfig.loginBtnLinkColor || '#005eeb';
     document.documentElement.style.setProperty('--login-btn-link-color', loginBtnLinkColor.value);


### PR DESCRIPTION
## Summary
- require captcha verification for every login attempt and invalidate captcha identifiers after use on the backend
- update the login page to always display and validate the captcha, removing the ignore-captcha flag from the frontend store and API types

## Testing
- go test ./... *(fails: missing embedded assets in cmd/server/web)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2eaad0608321830c99744f8a0163